### PR TITLE
ENH: Added check for makefile

### DIFF
--- a/jupinx/cmd/build.py
+++ b/jupinx/cmd/build.py
@@ -111,7 +111,8 @@ def handle_make_preview(arg_dict):
     Handle preview targeting from options specified through CLI
     TODO: Support individual lecture targeting
     """
-    print(arg_dict['view'])
+    if check_directory_makefile(arg_dict) is False:
+        exit()
     target = str(arg_dict['view']).lower()
     if target == "website":
         cmd = ['make', 'preview', 'target=website', 'PORT=8900']


### PR DESCRIPTION
Have added a check to ensure Makefile is present in the directory where preview is run.
Also @mmcky @jstac , should we also handle the case to check the open ports and assign a new port every time `jupinx --view=notebooks` is called?