### PR TITLE
FEAT: Add view directory check

### DIFF
--- a/jupinx/cmd/build.py
+++ b/jupinx/cmd/build.py
@@ -110,6 +110,20 @@ def check_directory_makefile(arg_dict):
        logging.error("Makefile not found in the directory")
        return False
 
+def check_view_result_directory(target, arg_dict):
+    if target == "notebooks":
+        dir = arg_dict['directory'] + "_build/jupyter/"
+    elif target == "website":
+        dir = arg_dict['directory'] + "_build/website/jupyter_html/"
+    else:
+        logging.error("target must be directory or website for the -v, --view option")
+    if os.path.exists(dir) is False:
+        if target == "notebooks":
+            logging.error("Results directory: {} does not exist!\nPlease run jupinx -n to build notebooks".format(dir))
+        elif target == "website":
+            logging.error("Results directory: {} does not exist.\n Please run jupinx -w to build website".format(dir))
+        return False
+
 def handle_make_parallel(cmd, arg_dict):
     if check_directory_makefile(arg_dict) is False:
         exit()
@@ -140,6 +154,8 @@ def handle_make_preview(arg_dict):
     if check_directory_makefile(arg_dict) is False:
         exit()
     target = str(arg_dict['view']).lower()
+    if check_view_result_directory(target, arg_dict) is False:
+        exit()
     if target == "website":
         cmd = ['make', 'preview', 'target=website', 'PORT=8900']
         print("Running: " + " ".join(cmd))

--- a/jupinx/cmd/build.py
+++ b/jupinx/cmd/build.py
@@ -75,6 +75,14 @@ def get_parser() -> argparse.ArgumentParser:
                             [Result: _build/website/]
                             """.lstrip("\n"))
     )
+    parser.add_argument('-v', '--view', dest='view', nargs='?', type=str, const='notebooks', action='store',
+                    help=textwrap.dedent("""
+                        Once build is complete open a server to view results for
+                        1. notebooks
+                        2. website
+                        [Default: --view will result in --view=notebooks]
+                        Example: jupinx -w lecture-source --view=website
+                        """.lstrip("\n"))
     parser.add_argument('--version', action='version', dest='show_version',
                         version='%%(prog)s %s' % __display_version__)
     group = parser.add_argument_group(__('additional options'))
@@ -84,14 +92,6 @@ def get_parser() -> argparse.ArgumentParser:
                             [Default: --parallel will result in --parallel=2 if no value is specified]
                             """.lstrip("\n"))
     )
-    group.add_argument('-v', '--view', dest='view', nargs='?', type=str, const='notebooks', action='store',
-                        help=textwrap.dedent("""
-                            Once build is complete open a server to view results for
-                            1. notebooks
-                            2. website
-                            [Default: --view will result in --view=notebooks]
-                            Example: jupinx -w lecture-source --view=website
-                            """.lstrip("\n"))
     )
     return parser
 


### PR DESCRIPTION
This PR enables `-v, --view` to be used independent of other build request and checks for a result directory. 