### PR TITLE
FIX: Sphinx version requirement specification in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,12 @@ This package contains the Jupinx extension.
 .. add description here ..
 '''
 
-requires = ['Sphinx>=1.8.5']
-
 install_requires = [
     'docutils', 
     'nbformat', 
-    'sphinx', 
+    'sphinx>=1.8.5', 
     'dask', 
+    'dask[distributed]'
     'ipython', 
     'nbconvert', 
     'jupyter_client'


### PR DESCRIPTION
requirement of sphinx >= 1.8.5 specified in the setup file and dask distributed also added in install requires.

fixes #32 