### PR TITLE
FIX: Specifying a minimum pyzmq requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,11 @@ install_requires = [
     'nbformat', 
     'sphinx>=1.8.5', 
     'dask', 
-    'dask[distributed]'
+    'dask[distributed]',
     'ipython', 
     'nbconvert', 
-    'jupyter_client'
+    'jupyter_client',
+    'pyzmq>=17.1.3'
 ]
 
 setup(


### PR DESCRIPTION
To counter the following warning - `VisibleDeprecationWarning: zmq.eventloop.minitornado is deprecated in pyzmq 14.0 and will be removed.` , a minimum pyzmq version of 17.1.3 is required. 
This PR fixes this issue.
fix #33 