### PR TITLE
Jupinx icon links to home, GH pages run locally #43

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 
 docs/sphinx/_build/
 docs/_site
+docs/Gemfile.lock
 
 jupinx/cmd/__pycache__/
 jupinx/util/__pycache__/

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'github-pages', group: :jekyll_plugins

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -45,7 +45,12 @@
 
 </head>
 
+{% if page.permalink == '/' %}
+<body class="home">
+{% else %}
 <body>
+{% endif %}
+
 
   <h1 class="sr-only">Jupinx</h1>
 
@@ -75,11 +80,11 @@
 
       <div class="header-branding">
 
-        <p class="header-logo"><img src="jupinx-logo.png" alt="Jupinx logo"></p>
+        <p class="header-logo"><a href="{{ "/" | relative_url }}"><img src="jupinx-logo.png" alt="Jupinx logo"></a></p>
 
         <p class="header-tagline">Welcome to Jupinx, a build system for lectures.</p>
 
-        <p>Jupinx is an open source tool built by <a href="https://quantecon.org/">QuantEcon</a> for building <a href="https://lectures.quantecon.org/">QuantEcon lectures</a> 
+        <p class="header-description">Jupinx is an open source tool built by <a href="https://quantecon.org/">QuantEcon</a> for building <a href="https://lectures.quantecon.org/">QuantEcon lectures</a> 
           from RST to a collection of <a href="http://jupyter.org">Jupyter Notebooks</a>. It is a collection of utilities for working with 
           <a href="http://www.sphinx-doc.org/en/master/">Sphinx</a> and <a href="http://jupyter.org">Jupyter Notebooks</a>.</p>
 
@@ -90,7 +95,11 @@
         <ul>
           <li><a href="https://jupinx.readthedocs.io/" class="button">Documentation</a></li>
           <li><a href="https://github.com/QuantEcon/jupinx" class="button">Repository</a></li>
+          {% if page.title == 'Tutorial' %}
+          <li class="active"><a href="{{ "tutorial" | relative_url }}" class="button">Tutorial</a></li>
+          {% else %}
           <li><a href="{{ "tutorial" | relative_url }}" class="button">Tutorial</a></li>
+          {% endif %}
         </ul>
 
       </div>

--- a/docs/site.css
+++ b/docs/site.css
@@ -37,7 +37,7 @@ img {
   display: block;
   background-color: #d8655e;
   font-size: 0.9rem;
-  padding: 0.5rem 1rem;
+  padding: 0.25rem 1rem;
   color: #fff;
   border-radius: .25rem;
   border: 1px solid rgba(0,0,0,.2);
@@ -53,7 +53,7 @@ img {
 .wrapper {
   max-width:960px;
   margin:0 auto;
-  padding:4rem 4rem;
+  padding:2rem 4rem;
 }
 
 .header {
@@ -61,18 +61,36 @@ img {
 }
 
 .header .wrapper {
+  padding:1rem 4rem;
+}
+
+.home .header .wrapper {
+  padding: 2rem 4rem;
 }
 
 .header-branding {
   
 }
 
-.header-logo {
+.header-logo img {
+  max-width: 350px;
+}
+
+.home .header-logo img {
+  max-width: none;
 }
 
 .header-tagline {
   font-size: 1.4rem;
   color: #7a7a7a;
+}
+
+.header-description {
+  display: none;
+}
+
+.home .header-description {
+  display: block;
 }
 
 .header-links {
@@ -87,9 +105,22 @@ img {
 }
 
 .header-links ul li {
-  margin:0 1rem 1rem 0;
+  margin:0 0.5rem 1rem 0.5rem;
   display: inline-block;
   min-width: 150px;
+}
+
+.header-links ul li.active a {
+  color:#fff;
+  background-color: #a04a45;
+  cursor: default;
+}
+
+.section h1 {
+  text-align: center;
+  font-size: 2.5rem;
+  margin: 1rem 0 4rem 0;
+  color: #d8655e;
 }
 
 .section h2 {


### PR DESCRIPTION
This PR adds functionality to run the GH pages site locally for authoring and testing.

To run locally, switch to the site root directory (/docs) and run (https://help.github.com/en/articles/setting-up-your-github-pages-site-locally-with-jekyll):
`bundle exec jekyll serve`

Also added a link on the site logo to home.