### PR TITLE
ENH: Adjust view mechanism

### DIFF
--- a/docs/sphinx/jupinx.rst
+++ b/docs/sphinx/jupinx.rst
@@ -63,7 +63,7 @@ completely built (including all code and generated components).
 
 .. note::
 
-    There is currently no default template provided for constructing websites.
+    There is currently **no** default template provided for constructing websites.
     This needs to be provided in the future to allow building websites out of
     the box with a default theme.
 
@@ -95,28 +95,24 @@ The typical usage for ``jupinx`` is:
 
 .. code-block:: bash
 
-    jupinx [BUILDOPTIONS] <PATH-PROJECT-DIRECTORY> [OPTIONS]
+    jupinx [OPTIONS] <DIRECTORY> [ADDITIONAL OPTIONS]
 
-The following **build** options are provided:
+The following **options** are provided:
 
--n, --notebooks     compile a set of Jupyter notebooks
-                    [_build/jupyter]
--w, --website       compile notebooks and convert to HTML
-                    [_build/website]
--c, --coverage      compile notebooks and run coverage tests
-                    [_build/coverage]
+-h, --help            show this help message and exit
+-c, --clean           clean build so sphinx recompiles all source documents
+-j, --jupyterhub      open jupyter server when build completes to view notebooks
+-n, --notebooks       compile a collection of Jupyter notebooks
+                    [Result: _build/jupyter]
+-s, --server          open html server when build completes to view website
+-t, --coverage-tests  compile coverage report for project
+                    [Result: <project-directory>/_build/coverage/reports/{filename}.json]
+-w, --website         compile a website through Jupyter notebooks
+                    [Result: _build/website/]
+--version             show program's version number and exit
 
+The following **additional options** are provided:
 
-Additional options include:
-
--p, --parallel          request notebook execution and conversion 
-                        to be processed in parallel. An integer 
-                        may be specified to assign the number of 
-                        dask workers. [**Default:** 2] 
-                        *Example:* jupinx -w -p=4
-
-.. todo::
-
-    implement -v, --view for automatically loading jupyter notebook or 
-    web server for viewing generated outputs on your local machine.
-    See [Issue #21](https://github.com/QuantEcon/jupinx/issues/21)
+  -p [PARALLEL], --parallel [PARALLEL]
+                        Specify the number of workers for parallel execution 
+                        [Default: --parallel will result in --parallel=2 if no value is specified]

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -147,14 +147,19 @@ jupinx --notebooks
 
 will generate notebooks from the `rst` files and place them in `_build/jupyter/`
 
-You can open a jupyter server in this directory to see the results
+You can view the results by launching a Jupyter notebook server using:
 
 ```bash
-cd _build/jupyter
-jupyter notebook
+jupinx --jupyterhub
 ```
 
-> **_NOTE:_**  In future this should be added to `jupinx`. See [Issue #21](https://github.com/QuantEcon/jupinx/issues/21)
+It is also possible to specify these options together (using short notation):
+
+```bash
+jupinx -nj
+```
+
+which will build the notebooks and then launch the Jupyter notebook server
 
 
 Step 5: Advanced Configuration of `sphinxcontrib-jupyter`
@@ -170,12 +175,11 @@ options. You can add:
 jupyter_execute_notebooks = True
 ```
 
-this will now build notebooks and then excecute them for you with results stored in 
+this will now build notebooks and then execute them for you with results stored in 
 `_build/jupyter/executed`. You can test this by:
 
 ```bash
-make clean    #Clear Sphinx Cache to Rebuild Files from Scratch
-make jupyter
+jupinx --clean --notebooks
 ```
 
 > **_NOTE:_** The [sphinxcontrib-jupyter documentation](https://sphinxcontrib-jupyter.readthedocs.io/en/latest/config-project.html) has a section on Managing Large Projects that may require different compilation pipelines for editing and publishing. 

--- a/jupinx/cmd/build.py
+++ b/jupinx/cmd/build.py
@@ -153,43 +153,45 @@ def handle_make_parallel(cmd, arg_dict):
             subprocess.run(cmd, cwd=arg_dict['directory'])
 
 def handle_make_jupyterhub(arg_dict):
-    """ Launch Jupyterhub Server """
+    """ Launch Jupyterhub Server (PORT = 8900) """
+    PORT = 8900
     if check_directory_makefile(arg_dict) is False:
         exit()
     if check_view_result_directory("notebooks", arg_dict) is False:
         exit()
-    cmd = ['make', 'preview', 'PORT=8900']
+    cmd = ['make', 'preview', 'PORT={}'.format(PORT)]
     print("Running: " + " ".join(cmd))
-    catch_keyboard_interrupt("notebooks", cmd, arg_dict['directory'])
+    catch_keyboard_interrupt("notebooks", cmd, arg_dict['directory'], PORT)
 
 def handle_make_htmlserver(arg_dict):
-    """ Launch HTML Sever """
+    """ Launch HTML Sever (PORT = 8901) """
+    PORT = 8901
     if check_directory_makefile(arg_dict) is False:
         exit()
     if check_view_result_directory("website", arg_dict) is False:
         exit()
-    cmd = ['make', 'preview', 'target=website', 'PORT=8900']
+    cmd = ['make', 'preview', 'target=website', 'PORT={}'.format(PORT)]
     print("Running: " + " ".join(cmd))
-    catch_keyboard_interrupt("website", cmd, arg_dict['directory'])
+    catch_keyboard_interrupt("website", cmd, arg_dict['directory'], PORT)
 
-def catch_keyboard_interrupt(target, cmd, cwd):
+def catch_keyboard_interrupt(target, cmd, cwd, port):
     """ Run subprocess.run call to catch Keyboard Interrupts """
     try:
         p = subprocess.Popen(cmd, cwd=cwd)
         # subprocess.run(cmd, cwd=cwd)
         if target == "website":
-            webbrowser.open("http://localhost:8900")
+            webbrowser.open("http://localhost:{}".format(port))
         print("\nTo close the server press Ctrl-C\n")
         #Wait for User to use Ctrl-C
         while p:
             pass
     except KeyboardInterrupt:
         if target == 'notebooks':
-            subprocess.run(['jupyter', 'notebook', 'stop', '8900'])   #Stop Notebook Server
-            p.kill()                                                  #Kill make process
-            print("\nClosing notebook server on port 8900")
+            subprocess.run(['jupyter', 'notebook', 'stop', '{}'.format(port)])   #Stop Notebook Server
+            p.kill()                                                  #Kill process
+            print("\nClosing notebook server on port {}".format(port))
         else:
-            print("\nClosing website server process ...")
+            print("\nClosing website server process on port {}".format(port))
 
 def make_file_actions(arg_dict: Dict):
     """

--- a/jupinx/cmd/build.py
+++ b/jupinx/cmd/build.py
@@ -63,9 +63,10 @@ def get_parser() -> argparse.ArgumentParser:
                         """.lstrip("\n"))
     )
     parser.add_argument('-j', '--jupyterhub', action='store_true', dest='jupyterhub',
-                        help=text.wrap.dedend("""
+                        help=textwrap.dedent("""
                         open jupyter server when build completes to view notebooks
-                        """.lstring("\n")))
+                        """.lstrip("\n"))
+    )
     parser.add_argument('-n', '--notebooks', action='store_true', dest='jupyter',
                         help=textwrap.dedent("""
                             compile a collection of Jupyter notebooks
@@ -73,9 +74,10 @@ def get_parser() -> argparse.ArgumentParser:
                              """.lstrip("\n"))
     )
     parser.add_argument('-s', '--server', action='store_true', dest='html-server',
-                        help=text.wrap.dedend("""
+                        help=textwrap.dedent("""
                         open html server when build completes to view website
-                        """.lstrip("\n")))
+                        """.lstrip("\n"))
+    )
     parser.add_argument('-t', '--coverage-tests', action='store_true', dest='coverage',
                         help=textwrap.dedent("""
                             compile coverage report for project
@@ -158,7 +160,7 @@ def handle_make_jupyterhub(arg_dict):
         exit()
     cmd = ['make', 'preview', 'PORT=8900']
     print("Running: " + " ".join(cmd))
-    catch_keyboard_interrupt(target, cmd, arg_dict['directory'])
+    catch_keyboard_interrupt("notebooks", cmd, arg_dict['directory'])
 
 def handle_make_htmlserver(arg_dict):
     """ Launch HTML Sever """
@@ -168,7 +170,7 @@ def handle_make_htmlserver(arg_dict):
         exit()
     cmd = ['make', 'preview', 'target=website', 'PORT=8900']
     print("Running: " + " ".join(cmd))
-    catch_keyboard_interrupt(target, cmd, arg_dict['directory'])
+    catch_keyboard_interrupt("website", cmd, arg_dict['directory'])
 
 def catch_keyboard_interrupt(target, cmd, cwd):
     """ Run subprocess.run call to catch Keyboard Interrupts """
@@ -222,7 +224,7 @@ def make_file_actions(arg_dict: Dict):
         handle_make_jupyterhub(arg_dict)
     
     if 'html-server' in arg_dict:
-        handle_make_htmlserver(argdict)
+        handle_make_htmlserver(arg_dict)
 
 
 def deleteDefaultValues(d):


### PR DESCRIPTION
This PR:

Deprecates:

1. ``-v, --view = {'notebooks', 'website'}``

Adds:

1. adds `-j, --jupyterhub` to launch `jupyter notebook` in the appropriate results directory
1. adds `-s, --server` to launch an `html` server in the appropriate results directory