### PR TITLE
ENH: Added functionality to specify individual files to compile

### DIFF
--- a/docs/sphinx/jupinx.rst
+++ b/docs/sphinx/jupinx.rst
@@ -113,3 +113,5 @@ The following **additional options** are provided:
 -p [PARALLEL], --parallel [PARALLEL]
                     Specify the number of workers for parallel execution 
                     (Default: --parallel will result in --parallel=2)
+-f [FILES [FILES ...]], --files [FILES [FILES ...]]
+                     specify files for compilation

--- a/jupinx/cmd/build.py
+++ b/jupinx/cmd/build.py
@@ -23,7 +23,8 @@ import textwrap
 
 ADDITIONAL_OPTIONS = [
     'directory',
-    'parallel'
+    'parallel',
+    'files'
 ]
 
 logging.basicConfig(format='%(levelname)s: %(message)s')
@@ -80,6 +81,7 @@ def get_parser() -> argparse.ArgumentParser:
                             [Result: _build/website/]
                             """.lstrip("\n"))
     )
+    parser.add_argument('-f', '--files',nargs="*", dest='files')
     parser.add_argument('--version', action='version', dest='show_version',
                         version='%%(prog)s %s' % __display_version__)
     group = parser.add_argument_group(__('additional options'))
@@ -132,24 +134,16 @@ def check_view_result_directory(target, arg_dict):
 def handle_make_parallel(cmd, arg_dict):
     if check_directory_makefile(arg_dict) is False:
         exit()
-    if sys.version_info.major == 2:
-        if 'parallel' in arg_dict:
-            cmd = ['make', cmd, 'parallel=' + str(arg_dict['parallel'])]
-            print("Running: " + " ".join(cmd))
-            subprocess.call(cmd, cwd=arg_dict['directory'])
-        else:
-            cmd = ['make', cmd]
-            print("Running: " + " ".join(cmd))
-            subprocess.call(cmd, cwd=arg_dict['directory'])
+    if 'parallel' in arg_dict:
+        cmd = ['make', cmd, 'parallel=' + str(arg_dict['parallel'])]
+        print("Running: " + " ".join(cmd))
     else:
-        if 'parallel' in arg_dict:
-            cmd = ['make', cmd, 'parallel=' + str(arg_dict['parallel'])]
-            print("Running: " + " ".join(cmd))
-            subprocess.run(cmd, cwd=arg_dict['directory'])
-        else:
-            cmd = ['make', cmd]
-            print("Running: " + " ".join(cmd))
-            subprocess.run(cmd, cwd=arg_dict['directory'])
+        cmd = ['make', cmd]
+        print("Running: " + " ".join(cmd))
+
+    if 'files' in arg_dict:
+        cmd = cmd + ['FILES='+ ' '.join(arg_dict['files'])]
+    subprocess.run(cmd, cwd=arg_dict['directory'])
 
 def handle_make_preview(arg_dict):
     """
@@ -253,7 +247,6 @@ def main(argv: List[str] = sys.argv[1:]) -> int:
         return err.code
    
     d = vars(args)
-
 
     [d, valid] = deleteDefaultValues(d)
 

--- a/jupinx/cmd/build.py
+++ b/jupinx/cmd/build.py
@@ -45,6 +45,7 @@ def get_parser() -> argparse.ArgumentParser:
         "Examples:\n"
         "    jupinx --notebooks (within a project directory)\n"
         "    jupinx -n lecture-source-py (specify path to project directory)\n"
+        "    jupinx -n lecture-source-py -f source/lecture1.rst"
         "\n"
         "Further documentation is available: https://quantecon.github.io/jupinx/.\n"
     )
@@ -62,13 +63,13 @@ def get_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument('-c', '--clean', action='store_true', dest='clean',
                         help=textwrap.dedent("""
-                        clean build directory
-                        """.lstrip("\n"))
+                            clean build directory
+                            """.lstrip("\n"))
     )
     parser.add_argument('-j', '--jupyternb', action='store_true', dest='jupyternb',
                         help=textwrap.dedent("""
-                        open jupyter to view notebooks
-                        """.lstrip("\n"))
+                            open jupyter to view notebooks
+                            """.lstrip("\n"))
     )
     parser.add_argument('-n', '--notebooks', action='store_true', dest='jupyter',
                         help=textwrap.dedent("""
@@ -77,8 +78,8 @@ def get_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument('-s', '--server', action='store_true', dest='html-server',
                         help=textwrap.dedent("""
-                        open html server to view website
-                        """.lstrip("\n"))
+                            open html server to view website
+                            """.lstrip("\n"))
     )
     parser.add_argument('-t', '--coverage-tests', action='store_true', dest='coverage',
                         help=textwrap.dedent("""
@@ -90,7 +91,6 @@ def get_parser() -> argparse.ArgumentParser:
                             compile website 
                             """.lstrip("\n"))
     )
-    parser.add_argument('-f', '--files',nargs="*", dest='files')
     parser.add_argument('--version', action='version', dest='show_version',
                         version='%%(prog)s %s' % __display_version__)
     group = parser.add_argument_group(__('additional options'))
@@ -98,6 +98,11 @@ def get_parser() -> argparse.ArgumentParser:
                         help=textwrap.dedent("""
                             Specify the number of workers for parallel execution 
                             (Default: --parallel will result in --parallel=2)
+                            """.lstrip("\n"))
+    )
+    group.add_argument('-f', '--files', nargs="*", dest='files',
+                        help=textwrap.dedent("""
+                            specify files for compilation
                             """.lstrip("\n"))
     )
     return parser

--- a/jupinx/templates/quickstart/Makefile_t
+++ b/jupinx/templates/quickstart/Makefile_t
@@ -11,10 +11,11 @@ BUILDWEBSITE  = {{ rbuilddir }}/website
 BUILDCOVERAGE = {{ rbuilddir }}/coverage
 BUILDPDF      = {{ rbuilddir }}/pdf
 PORT          = 8888
+FILES         = 
 
 # Put it first so that "make" without argument is like "make help".
 help:
-	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(FILES) $(SPHINXOPTS) $(O)
 
 .PHONY: help Makefile
 
@@ -31,21 +32,21 @@ endif
 
 coverage:
 ifneq ($(strip $(parallel)),)
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_execute_notebooks=1 -D jupyter_ignore_skip_test=0 -D jupyter_number_workers=$(parallel) 
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(FILES) $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_execute_notebooks=1 -D jupyter_ignore_skip_test=0 -D jupyter_number_workers=$(parallel) 
 else
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_execute_notebooks=1 -D jupyter_ignore_skip_test=0
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDCOVERAGE)" $(FILES) $(SPHINXOPTS) $(O) -D jupyter_make_coverage=1 -D jupyter_execute_notebooks=1 -D jupyter_ignore_skip_test=0
 endif
 
 website:
 ifneq ($(strip $(parallel)),)
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDWEBSITE)" $(SPHINXOPTS) $(O) -D jupyter_make_site=1 -D jupyter_generate_html=1 -D jupyter_download_nb=1 -D jupyter_execute_notebooks=1 -D jupyter_target_html=1 -D jupyter_images_markdown=0 -D jupyter_html_template="theme/templates/lectures-nbconvert.tpl" -D jupyter_coverage_dir=$(BUILDCOVERAGE) -D jupyter_number_workers=$(parallel)
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDWEBSITE)" $(FILES) $(SPHINXOPTS) $(O) -D jupyter_make_site=1 -D jupyter_generate_html=1 -D jupyter_download_nb=1 -D jupyter_execute_notebooks=1 -D jupyter_target_html=1 -D jupyter_images_markdown=0 -D jupyter_html_template="theme/templates/lectures-nbconvert.tpl" -D jupyter_coverage_dir=$(BUILDCOVERAGE) -D jupyter_number_workers=$(parallel)
 
 else
-	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDWEBSITE)" $(SPHINXOPTS) $(O) -D jupyter_make_site=1 -D jupyter_generate_html=1 -D jupyter_download_nb=1 -D jupyter_execute_notebooks=1 -D jupyter_target_html=1 -D jupyter_images_markdown=0 -D jupyter_html_template="theme/templates/lectures-nbconvert.tpl" -D jupyter_coverage_dir=$(BUILDCOVERAGE)
+	@$(SPHINXBUILD) -M jupyter "$(SOURCEDIR)" "$(BUILDWEBSITE)" $(FILES) $(SPHINXOPTS) $(O) -D jupyter_make_site=1 -D jupyter_generate_html=1 -D jupyter_download_nb=1 -D jupyter_execute_notebooks=1 -D jupyter_target_html=1 -D jupyter_images_markdown=0 -D jupyter_html_template="theme/templates/lectures-nbconvert.tpl" -D jupyter_coverage_dir=$(BUILDCOVERAGE)
 endif
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(FILES) $(SPHINXOPTS) $(O)
 


### PR DESCRIPTION
Individual file names can now be specified in the jupinx build tool to specifically target those filenames.
argument to specify the files are `-f` or `--files` .

Example usage :- 
`jupinx -n -f  source/rst/index.rst source/rst/amss.rst`

Note:- If no directory is specified then the path of files is relative to the current directory else the path is relative to the directory specified.

**Note:** **This PR also removes the python2 support code from build tool.** 

fixes #30 #46 

needs discussion with @mmcky  to update the help tool and docs