### PR TITLE
Relative path issue fix

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -17,10 +17,10 @@
   <title>Jupinx</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="stylesheet" type="text/css" href="{{ "/site.css" | relative_url }}">
+  <link rel="stylesheet" type="text/css" href="/site.css">
   <link rel="stylesheet" href="https://assets.quantecon.org/css/qemb.css">
 
-  <link rel="icon" type="image/x-icon" href="{{ "/favicon.ico" | relative_url }}" />
+  <link rel="icon" type="image/x-icon" href="/favicon.ico" />
 
   <link href="https://fonts.googleapis.com/css?family=Quicksand:400,700&display=swap" rel="stylesheet">
 
@@ -98,7 +98,7 @@
 
       <div class="header-branding">
 
-        <p class="header-logo"><a href="{{ "/" | relative_url }}"><img src="jupinx-logo.png" alt="Jupinx logo"></a></p>
+        <p class="header-logo"><a href="/"><img src="jupinx-logo.png" alt="Jupinx logo"></a></p>
 
         <p class="header-tagline">Welcome to Jupinx, a build system for lectures.</p>
 
@@ -115,9 +115,9 @@
           <li><a href="https://jupinx.readthedocs.io/" class="button">Documentation</a></li>
           <li><a href="https://github.com/QuantEcon/jupinx" class="button">Repository</a></li>
           {% if page.title == 'Tutorial' %}
-          <li class="active"><a href="{{ "tutorial" | relative_url }}" class="button">Tutorial</a></li>
+          <li class="active"><a href="/tutorial" class="button">Tutorial</a></li>
           {% else %}
-          <li><a href="{{ "tutorial" | relative_url }}" class="button">Tutorial</a></li>
+          <li><a href="/tutorial" class="button">Tutorial</a></li>
           {% endif %}
         </ul>
 


### PR DESCRIPTION
When moving to `jupinx.quantecon.org` links no longer required `/jupinx/` prefix.