### PR TITLE
FIX: add sphinxcontrib dependencies on install of Jupinx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ install_requires = [
     'ipython', 
     'nbconvert', 
     'jupyter_client',
-    'pyzmq>=17.1.3'
+    'pyzmq>=17.1.3',
+    'sphinxcontrib-bibtex',
+    'sphinxcontrib-jupyter'
 ]
 
 setup(


### PR DESCRIPTION
This ensures all dependencies from `sphinxcontrib` are met when installing in new environments. 

Adds to `install_requires`:
1. `sphinxcontrib-bibtex`
1. `sphinxcontrib-jupyter`