### PR TITLE
FIX: add minimum version for sphinxcontrib-jupyter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     'jupyter_client',
     'pyzmq>=17.1.3',
     'sphinxcontrib-bibtex',
-    'sphinxcontrib-jupyter'
+    'sphinxcontrib-jupyter>=0.4.1'
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     'jupyter_client',
     'pyzmq>=17.1.3',
     'sphinxcontrib-bibtex',
-    'sphinxcontrib-jupyter>=0.4.1'
+    'sphinxcontrib-jupyter>=0.4.0'
 ]
 
 setup(


### PR DESCRIPTION
@AakashGfude we should probably specify minimum version numbers here for `sphinxcontrib-jupyter`.  Can you please review this to make sure I have the right syntax, Thanks.

This isn't specifically a requirement -- but it would be nice to keep users of `jupinx` up to date on `sphinxcontrib-jupyter`