### PR TITLE
FEAT: add pdf support

### DIFF
--- a/docs/sphinx/jupinx.rst
+++ b/docs/sphinx/jupinx.rst
@@ -103,6 +103,7 @@ The following **options** are provided:
 -c, --clean           clean build directory
 -j, --jupyternb       open jupyter to view notebooks
 -n, --notebooks       compile RST files to Jupyter notebooks
+-d, --pdf             compile RST files to PDF files
 -s, --server          open html server to view website
 -t, --coverage-tests  compile coverage report for project
 -w, --website         compile website 

--- a/jupinx/cmd/build.py
+++ b/jupinx/cmd/build.py
@@ -77,7 +77,7 @@ def get_parser() -> argparse.ArgumentParser:
                             compile RST files to Jupyter notebooks
                              """.lstrip("\n"))
     )
-    parser.add_argument('-d', '--pdf', action='store_true', dest='pdf',
+    parser.add_argument('-p', '--pdf', action='store_true', dest='pdf',
                         help=textwrap.dedent("""
                             compile RST files to PDF files
                             """.lstrip("\n"))
@@ -100,13 +100,13 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('--version', action='version', dest='show_version',
                         version='%%(prog)s %s' % __display_version__)
     group = parser.add_argument_group(__('additional options'))
-    group.add_argument('-p', '--parallel', dest='parallel', nargs='?', type=int, const='2', action='store',
+    group.add_argument('--parallel', dest='parallel', nargs='?', type=int, const='2', action='store',
                         help=textwrap.dedent("""
                             Specify the number of workers for parallel execution 
                             (Default: --parallel will result in --parallel=2)
                             """.lstrip("\n"))
     )
-    group.add_argument('-f', '--files', nargs="*", dest='files',
+    group.add_argument('--files', nargs="*", dest='files',
                         help=textwrap.dedent("""
                             specify files for compilation
                             """.lstrip("\n"))

--- a/jupinx/cmd/build.py
+++ b/jupinx/cmd/build.py
@@ -251,13 +251,15 @@ def make_file_actions(arg_dict: Dict):
         check_xelatex_installed()
         handle_make_parallel('pdf', arg_dict)
 
-def check_xelatex_installed():
+def check_xelatex_installed(): 
     if not find_executable('xelatex'):
-        self.logger.warning(
+        logging.error(
             "Cannot find a xelatex executable for pdf compilation.\n" +
             "If you need to install tex it is recommended to install texlive: https://www.tug.org/texlive/"
         )
         exit(1)
+    else:
+        print("Using xelatex from: {}".format(find_executable('xelatex')))
 
 def check_project_path(path):
     """ Check supplied project directory is valid and complete """

--- a/jupinx/cmd/build.py
+++ b/jupinx/cmd/build.py
@@ -77,7 +77,7 @@ def get_parser() -> argparse.ArgumentParser:
                             compile RST files to Jupyter notebooks
                              """.lstrip("\n"))
     )
-    parser.add_argument('-p', '--pdf', action='store_true', dest='pdf',
+    parser.add_argument('-d', '--pdf', action='store_true', dest='pdf',
                         help=textwrap.dedent("""
                             compile RST files to PDF files
                             """.lstrip("\n"))
@@ -100,7 +100,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('--version', action='version', dest='show_version',
                         version='%%(prog)s %s' % __display_version__)
     group = parser.add_argument_group(__('additional options'))
-    group.add_argument('--parallel', dest='parallel', nargs='?', type=int, const='2', action='store',
+    group.add_argument('-p', '--parallel', dest='parallel', nargs='?', type=int, const='2', action='store',
                         help=textwrap.dedent("""
                             Specify the number of workers for parallel execution 
                             (Default: --parallel will result in --parallel=2)

--- a/jupinx/cmd/build.py
+++ b/jupinx/cmd/build.py
@@ -22,6 +22,7 @@ import webbrowser
 import textwrap
 from notebook import notebookapp
 from traitlets.config import Config
+from distutils.spawn import find_executable
 
 ADDITIONAL_OPTIONS = [
     'directory',
@@ -247,7 +248,16 @@ def make_file_actions(arg_dict: Dict):
         handle_make_htmlserver(arg_dict)
 
     if 'pdf' in arg_dict:
+        check_xelatex_installed()
         handle_make_parallel('pdf', arg_dict)
+
+def check_xelatex_installed():
+    if not find_executable('xelatex'):
+        self.logger.warning(
+            "Cannot find a xelatex executable for pdf compilation.\n" +
+            "If you need to install tex it is recommended to install texlive: https://www.tug.org/texlive/"
+        )
+        exit(1)
 
 def check_project_path(path):
     """ Check supplied project directory is valid and complete """

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     'jupyter_client',
     'pyzmq>=17.1.3',
     'sphinxcontrib-bibtex',
-    'sphinxcontrib-jupyter>=0.4.3'
+    'sphinxcontrib-jupyter>=0.5.0'
 ]
 
 setup(


### PR DESCRIPTION
This PR adds support for building `pdf` files. This requires sphinxcontrib>=0.5.0. 

Usage:

```bash
jupinx -p
```

or

```bash
jupinx --pdf
```

this disables short version for items requiring input such as ``--parallel`` and ``--files``