### PR TITLE
BUG: Fix pypi issue not including theme assets

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 recursive-include jupinx/templates *
+recursive-include jupinx/theme *

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ INSTALL_REQUIRES = [
 ]
 
 setup(
-    name='Jupinx',
+    name='jupinx',
     version=VERSION,
     url='https://github.com/QuantEcon/jupinx',
     download_url='https://github.com/QuantEcon/jupinx/archive/{}.tar.gz'.format(VERSION),


### PR DESCRIPTION
This PR fixes https://github.com/QuantEcon/jupinx/issues/75 and updates `Jupinx` to `jupinx` for pypi main page. 